### PR TITLE
Use POD ID for the container ID

### DIFF
--- a/lib/kubernetes-api.js
+++ b/lib/kubernetes-api.js
@@ -320,7 +320,7 @@ class KubernetesApi extends ApiImplementation {
             const newApp = _.isNil(_.get(csAppDesc, ['tags', 'constraints'])) ?
                 _.merge(csAppDesc, initializedConstraints) : csAppDesc;
 
-            const k8sDesc = 
+            const k8sDesc =
                 Translator.csApplicationToK8SReplicationController(_.merge(existingApp, newApp));
 
 
@@ -367,7 +367,7 @@ class KubernetesApi extends ApiImplementation {
             env_vars: { CS_ORCHESTRATOR: 'kubernetes' }
         }));
 
-        const k8sAppDesc = initialK8SAppDesc; 
+        const k8sAppDesc = initialK8SAppDesc;
 
         request({
             uri: `${this.k8sApiUrl}/api/v1/namespaces/default/replicationcontrollers`,
@@ -475,13 +475,15 @@ class KubernetesApi extends ApiImplementation {
 
                         const k8sContainer = _.get(pod, 'spec');
                         const status = _.get(pod, ['status', 'phase']);
-                        const containerID = _.replace(_.get(pod, ['status', 'containerStatuses', 0, 'containerID']), 'docker://', '');
+
+                        // This is fine since we only have one container per POD
+                        const containerID = _.get(pod, ['metadata', 'uid']);
 
                         const csContainer = _.merge(
                             Translator.csApplicationFromK8SPodSpec(k8sContainer),
                             {
                                 status: status === 'Running' ? 'loaded' : 'unloaded',
-                                container_id: _.replace(containerID, 'docker://', ''),
+                                container_id: containerID,
                                 id: containerID
                             });
 


### PR DESCRIPTION
* Since we only use one CONTAINER / POD, let's just use the POD UID
generated by kuberentes for our container ID.

Main reason for the change initially is that prometheus metrics received
from CADVISOR do not have a consistent docker ID for all metrics. Ex. is
`container_network_transmit_packets_total`. I cannot find out where the
docker ID returned by the metric is coming from, but all the other
labels are correctly associated with the POD. If we use POD UID as the
container ID we can easily pull metrics correctly.

@normanjoyner @jeremykross 