### PR TITLE
Delete applications bugs alternate

### DIFF
--- a/lib/kubernetes-api.js
+++ b/lib/kubernetes-api.js
@@ -92,7 +92,24 @@ class KubernetesApi extends ApiImplementation {
             body: KubernetesApi.k8sServiceDescriptionFor(k8sAppDesc, k8sPorts, discoveryPorts)
         };
 
-        request(req, cb);
+        return request(req, cb);
+    }
+
+    deleteService(app_name, cb) {
+        const service_name = `ser${_.join(_.take(String(encode(app_name)), 19), '')}`;
+
+        const req = {
+            uri: `${this.k8sApiUrl}/api/v1/namespaces/default/services/${service_name}`,
+            method: 'DELETE',
+        };
+
+        return request(req, (err, res) => {
+            if (err || res.statusCode !== 200) {
+                return cb(`Failed to delete service: ${service_name}`);
+            }
+
+            return cb(null, res);
+        });
     }
 
 
@@ -436,21 +453,41 @@ class KubernetesApi extends ApiImplementation {
 
                         console.log("Making final delete.");
 
-                        request({
-                            uri: `${self.k8sApiUrl}/api/v1/namespaces/default/replicationcontrollers/${name}`,
-                            method: 'DELETE'
-                        }, ifSuccessfulResponse(handler));
+                        async.parallel([
+                            (cb) => {
+                                return request({
+                                    uri: `${self.k8sApiUrl}/api/v1/namespaces/default/replicationcontrollers/${name}`,
+                                    method: 'DELETE'
+                                }, (err, res) => {
+                                    if (err || res.statusCode !== 200) {
+                                        return cb(`Failed to delete replication controller: ${name}`);
+                                    }
+
+                                    return cb(null, res);
+                                });
+                            },
+                            (cb) => {
+                                self.deleteService(name, cb);
+                            }
+                        ], (err) => {
+                            if (err) {
+                                return errorHandler(err);
+                            }
+
+                            return handler();
+                        });
 
                     } else {
-                        console.log("Trying again in 5 sec");
-                        setTimeout(safeDeleteRC, 5000);
+                        console.log("Trying again in 4 sec");
+                        setTimeout(safeDeleteRC, 4000);
                     }
                 }));
 
             }
 
-            safeDeleteRC();
-
+            // wait one second by default, so it always has
+            // a chance to scale down pods if they do exist
+            setTimeout(safeDeleteRC, 1000);
         });
 
     }

--- a/lib/kubernetes-api.js
+++ b/lib/kubernetes-api.js
@@ -96,6 +96,8 @@ class KubernetesApi extends ApiImplementation {
     }
 
     deleteService(app_name, cb) {
+        cb = this.sanitizeCallback(cb);
+
         const service_name = `ser${_.join(_.take(String(encode(app_name)), 19), '')}`;
 
         const req = {
@@ -105,10 +107,10 @@ class KubernetesApi extends ApiImplementation {
 
         return request(req, (err, res) => {
             if (err || res.statusCode !== 200) {
-                return cb(`Failed to delete service: ${service_name}`);
+                return cb.errorHandler(`Failed to delete service: ${service_name}`);
             }
 
-            return cb(null, res);
+            return cb.handler(res);
         });
     }
 
@@ -453,29 +455,10 @@ class KubernetesApi extends ApiImplementation {
 
                         console.log("Making final delete.");
 
-                        async.parallel([
-                            (cb) => {
-                                return request({
-                                    uri: `${self.k8sApiUrl}/api/v1/namespaces/default/replicationcontrollers/${name}`,
-                                    method: 'DELETE'
-                                }, (err, res) => {
-                                    if (err || res.statusCode !== 200) {
-                                        return cb(`Failed to delete replication controller: ${name}`);
-                                    }
-
-                                    return cb(null, res);
-                                });
-                            },
-                            (cb) => {
-                                self.deleteService(name, cb);
-                            }
-                        ], (err) => {
-                            if (err) {
-                                return errorHandler(err);
-                            }
-
-                            return handler();
-                        });
+                        return request({
+                            uri: `${self.k8sApiUrl}/api/v1/namespaces/default/replicationcontrollers/${name}`,
+                            method: 'DELETE'
+                        }, ifSuccessfulResponse(_.partial(this.deleteService, name, cb))); 
 
                     } else {
                         console.log("Trying again in 4 sec");

--- a/lib/kubernetes-api.js
+++ b/lib/kubernetes-api.js
@@ -100,6 +100,8 @@ class KubernetesApi extends ApiImplementation {
 
         const service_name = `ser${_.join(_.take(String(encode(app_name)), 19), '')}`;
 
+        console.log("Deleting service: " + service_name);
+
         const req = {
             uri: `${this.k8sApiUrl}/api/v1/namespaces/default/services/${service_name}`,
             method: 'DELETE',
@@ -435,7 +437,7 @@ class KubernetesApi extends ApiImplementation {
 
         this.updateApplication(name, { tags: { constraints: {} }, count: 0 }, (err, res) => {
 
-            if(err) return errHandler(err);
+            if(err) return errorHandler(err);
 
             const self = this;
             function safeDeleteRC() {
@@ -458,7 +460,7 @@ class KubernetesApi extends ApiImplementation {
                         return request({
                             uri: `${self.k8sApiUrl}/api/v1/namespaces/default/replicationcontrollers/${name}`,
                             method: 'DELETE'
-                        }, ifSuccessfulResponse(_.partial(this.deleteService, name, cb))); 
+                        }, ifSuccessfulResponse(() => this.deleteService(name, cb))); 
 
                     } else {
                         console.log("Trying again in 4 sec");


### PR DESCRIPTION
@nicktate @normanjoyner 

Here's an alternative take on Nick's latest PR.

Save the slight performance gain from making these calls in parallel with async, I'm not sure anyone would argue Nick's solution is cleaner.  In general, I think the (err, res) => {} thing in JS should be considered anti-pattern.  In other languages, where we install listeners specifically for error and for success, it is an antipatern to handle both things in the same function.  I designed the api-bridge to support my preference in error handling, which is to say, optional everything with a fallback.  I do feel this is a demonstrably better solution in a lot of ways, both in terms of the cognitive burden of managing the error handling, the tendency to make mistakes in having to deal with errors where we're not ready to handle them (i.e. log, and throw it up the stack), and in the readability of the code.  The so-called callback Hell is compounded tremendously by having to do if(err) { la la la; } at every step.  The isAcceptableResponseFn() pattern that I use is designed to make responses from request behave like a sane API should.  Because (err, res) is so common in JS, I do allow our API to be accessed in that style.  The consumer of the API needn't know or care how it works if they like to do it that way, the API supports that.  I thought that was a good compromise.

Anyway, I respect you both a lot, and don't think you're strictly incorrect in sticking to convention.  I would just warn that tolerance of unfamiliarity is a necessary prerequisite for improvement.  Or, with slightly more snark, if you program exactly like the average programmer, you'll likely be quite average.  I don't want to do battle, that's the last I'll say about this.

