### PR TITLE
Fixed the update application call

### DIFF
--- a/lib/kubernetes-api.js
+++ b/lib/kubernetes-api.js
@@ -15,7 +15,6 @@ const CSUtil = require('containership.utils');
 
 const DEFAULT_K8S_API_URL = 'http://localhost:8080';
 const DEFAULT_ETCD_API_URL = 'http://localhost:2379';
-
 class KubernetesApi extends ApiImplementation {
 
     constructor(k8sApiIP, k8sApiPort) {
@@ -34,7 +33,8 @@ class KubernetesApi extends ApiImplementation {
         this.defaultErrorHandler = (err) => {
 
             // eslint-disable-next-line no-console
-            console.log(`There was an error in the K8S Api Bridge: ${err}`);
+            console.log(`There was an error in the K8S Api Bridge:`);
+            console.error(err);
         };
 
         this.ifSuccessfulResponse =
@@ -85,30 +85,43 @@ class KubernetesApi extends ApiImplementation {
 
     //private, k8s services are analogous to cs service-discovery.
     createService(k8sAppDesc, k8sPorts, discoveryPorts, cb) {
+        const{ handler, errorHandler } = this.sanitizeCallback(cb);
+
+        const service_body = KubernetesApi.k8sServiceDescriptionFor(k8sAppDesc, k8sPorts, discoveryPorts);
+        const app_name = _.get(k8sAppDesc, ['metadata', 'name']);
+
         const req = {
             uri: `${this.k8sApiUrl}/api/v1/namespaces/default/services`,
             method: 'POST',
             json: true,
-            body: KubernetesApi.k8sServiceDescriptionFor(k8sAppDesc, k8sPorts, discoveryPorts)
+            body: service_body
         };
 
-        return request(req, cb);
+        return request(req, (err, res) => {
+            if(err || res.statusCode !== 201) {
+                return errorHandler(`Could not create service: ${service_body.metadata.name} for application: ${app_name}`);
+            }
+
+            return handler();
+        });
     }
 
     deleteService(app_name, cb) {
+        const{ handler, errorHandler } = this.sanitizeCallback(cb);
+
         const service_name = `ser${_.join(_.take(String(encode(app_name)), 19), '')}`;
 
         const req = {
             uri: `${this.k8sApiUrl}/api/v1/namespaces/default/services/${service_name}`,
-            method: 'DELETE',
+            method: 'DELETE'
         };
 
         return request(req, (err, res) => {
-            if (err || res.statusCode !== 200) {
-                return cb(`Failed to delete service: ${service_name}`);
+            if(err || res.statusCode !== 200) {
+                return errorHandler(`Failed to delete service: ${service_name}`);
             }
 
-            return cb(null, res);
+            return handler();
         });
     }
 
@@ -157,106 +170,142 @@ class KubernetesApi extends ApiImplementation {
     }
 
     getApplications(cb) {
+        const{ handler, errorHandler } = this.sanitizeCallback(cb);
 
-        cb = this.sanitizeCallback(cb);
-        const{ handler, errorHandler } = cb;
+        return async.parallel({
+            replicationControllers: (cb) => {
+                return request(`${this.k8sApiUrl}/api/v1/namespaces/default/replicationcontrollers`,
+                    (err, res, body) => {
+                        if(err || res.statusCode !== 200) {
+                            return cb('Failed to retrieve replication controllers inside getApplications');
+                        }
 
-        const ifSuccessfulResponse =
-            _.partialRight(this.ifSuccessfulResponse, {
-                errorHandler: errorHandler,
-                method: 'getApplications/'
-            });
+                        return cb(null, util.safeParse(body));
+                    });
+            },
+            services: (cb) => {
+                return request(`${this.k8sApiUrl}/api/v1/namespaces/default/services`,
+                    (err, res, body) => {
+                        if(err || res.statusCode !== 200) {
+                            return cb('Failed to retrieve the services inside getApplications');
+                        }
 
-        //Get the replication controllers
-        request(`${this.k8sApiUrl}/api/v1/namespaces/default/replicationcontrollers`,
-            ifSuccessfulResponse((replicationControllers) => {
-                replicationControllers = util.safeParse(replicationControllers.body);
+                        return cb(null, util.safeParse(body));
+                    });
+            },
+            hosts: (cb) => {
+                return this.getHosts((err, hosts) => {
+                    return cb(err, hosts);
+                });
+            },
+            containers: (cb) => {
+                return this.getContainers((err, containers) => {
+                    return cb(err, containers);
+                });
+            }
+        }, (err, responses) => {
+            if(err) {
+                return errorHandler(err);
+            }
 
-                //And the services (for discovery).
-                request(`${this.k8sApiUrl}/api/v1/namespaces/default/services`,
-                    ifSuccessfulResponse((services) => {
-                        services = util.safeParse(services.body);
+            const replicationControllers = responses.replicationControllers;
+            const services = responses.services;
+            const hosts = responses.hosts;
 
-                        this.getHosts((err, hosts) => {
+            const k8sItems = _.get(replicationControllers, 'items', []);
+            const k8sServices = _.get(services, 'items', []);
 
-                            // In cases where we rely on our own api methods in building a response,
-                            // we do use custom logic to propogate errors to the
-                            // user's handler rather than our own.
-                            if(err) {
-                                errorHandler(err); return;
-                            }
+            const allContainers = responses.containers;
 
-                            const k8sItems = _.get(replicationControllers, 'items', []);
-                            const k8sServices = _.get(services, 'items', []);
+            const containersByApp = _.reduce(allContainers, (result, container) => {
+                const appName = _.get(container, 'name');
+                const containers = _.get(result, appName, []);
+                return _.set(result, appName, _.concat(containers, container));
+            }, {});
 
-                            const allContainers = _.concat.apply(null, _.map(hosts, (h) => {
-                                const augmentedContainers =
-                                    _.map(_.get(h, 'containers'), (c) => {
-                                        return _.merge(c, {
-                                            host: h.id
-                                        });
-                                    });
-                                return augmentedContainers;
-                            }));
+            const csItems = _.map(k8sItems, _.flow(
+                Translator.csApplicationFromK8SReplicationController,
+                (csApp) => {
 
-                            const containersByApp = _.reduce(allContainers, (result, container) => {
-                                const appName = _.get(container, 'name');
-                                const containers = _.get(result, appName, []);
-                                return _.set(result, appName, _.concat(containers, container));
-                            }, {});
+                    //Augment the app with the discovery port.
+                    const k8sServiceForApp = _.first(_.filter(k8sServices, (s) =>
+                        _.get(s, ['spec', 'selector', 'app']) === csApp.id));
 
-                            const csItems = _.map(k8sItems, _.flow(
-                                Translator.csApplicationFromK8SReplicationController,
-                                (csApp) => {
+                    const discoveryPort = _.get(k8sServiceForApp, ['spec', 'ports', 0, 'nodePort']);
 
-                                    //Augment the app with the discovery port.
-                                    const k8sServiceForApp = _.first(_.filter(k8sServices, (s) =>
-                                        _.get(s, ['spec', 'selector', 'app']) === csApp.id));
+                    return discoveryPort ?
+                        _.merge(csApp, {'discovery_port': discoveryPort}) :
+                        csApp;
 
-                                    const discoveryPort = _.get(k8sServiceForApp, ['spec', 'ports', 0, 'nodePort']);
+                },
+                (csApp) => {
+                    return _.set(csApp, 'containers',
+                        _.get(containersByApp, csApp.id) || []);
+                }));
 
-                                    return discoveryPort ?
-                                        _.merge(csApp, {'discovery_port': discoveryPort}) :
-                                        csApp;
-
-                                },
-                                (csApp) => {
-                                    return _.set(csApp, 'containers',
-                                        _.get(containersByApp, csApp.id) || []);
-                                }));
-
-                            const csApps =
-                                _.merge.apply(null, _.map(csItems, (item) => {
-                                    return _.set({}, item.id, _.defaults(item, {
-                                        env_vars: {},
-                                        tags: {},
-                                        volumes: []
-                                    }));
-                                }));
-
-                            handler(csApps);
-                        });
+            const csApps =
+                _.merge.apply(null, _.map(csItems, (item) => {
+                    return _.set({}, item.id, _.defaults(item, {
+                        env_vars: {},
+                        tags: {},
+                        volumes: []
                     }));
-            }));
+                }));
+
+            return handler(csApps);
+        });
+    }
+
+    getContainers(cb) {
+        const{ handler, errorHandler } = this.sanitizeCallback(cb);
+
+        return request(`${this.k8sApiUrl}/api/v1/pods`,
+            (err, res, body) => {
+                if(err || res.statusCode !== 200) {
+                    return errorHandler('Failed to retrive k8s pods inside getContainers call');
+                }
+
+                const pods = _.map(util.safeParse(body).items, pod => {
+                    const nodeName = _.get(pod, 'spec.nodeName');
+                    const k8sContainer = _.get(pod, 'spec');
+                    const status = _.get(pod, 'status.phase');
+
+                    const containerID = _.get(pod, 'metadata.uid');
+
+                    const name = _.get(pod, 'status.containerStatuses[0].name');
+                    const image = _.get(pod, 'status.containerStatuses[0].image');
+
+                    const csContainer = _.merge(
+                        Translator.csApplicationFromK8SPodSpec(k8sContainer),
+                        {
+                            status: status === 'Running' ? 'loaded' : 'unloaded',
+                            container_id: containerID,
+                            id: containerID,
+                            name: name,
+                            image: image,
+                            host: nodeName
+                        }
+                    );
+
+                    return csContainer;
+                });
+
+                return handler(pods);
+            });
     }
 
     createContainers(appId, containerConfig, cb) {
+        const{ errorHandler } = this.sanitizeCallback(cb);
 
-        cb = this.sanitizeCallback(cb);
-
-        this.getApplications((err, apps) => {
-
-            const{ errorHandler } = cb;
-
+        return this.getApplications((err, apps) => {
             if(err) {
-                errorHandler(err); return;
+                return errorHandler(err);
             }
 
             const app = _.first(_.filter(apps, (v, k) => k == appId));
 
             if(!app) {
-                errorHandler(Error(`Couldn't find application with id ${appId} when in KubernetesApi::createContainer!`));
-                return;
+                return errorHandler(Error(`Couldn't find application with id ${appId} when in KubernetesApi::createContainer!`));
             }
 
             const containerCount = _.size(_.get(app, 'containers'));
@@ -266,51 +315,36 @@ class KubernetesApi extends ApiImplementation {
                 containerConfig,
                 {count: newCount}
             ), cb);
-
         });
     }
 
     deleteContainer(appId, containerId, cb) {
-        cb = this.sanitizeCallback(cb);
-        const{ errorHandler } = cb;
+        const{ errorHandler } = this.sanitizeCallback(cb);
 
-        this.getApplications((err, apps) => {
-
+        return this.getApplications((err, apps) => {
             if(err) {
-                errorHandler(err);
-                return;
+                return errorHandler(err);
             }
 
             const app = _.first(_.filter(apps, (v, k) => k == appId));
 
             if(!app) {
-                errorHandler(Error(`Couldn't find application with id ${appId} when in KubernetesApi::createContainer!`));
-                return;
+                return errorHandler(Error(`Couldn't find application with id ${appId} when in KubernetesApi::createContainer!`));
             }
 
             const containerCount = _.size(_.get(app, 'containers'));
             const newCount = containerCount - 1;
 
-            this.updateApplication(appId, {count: newCount}, cb);
+            return this.updateApplication(appId, {count: newCount}, cb);
         });
     }
 
     updateApplication(appId, csAppDesc, cb) {
+        const{ handler, errorHandler } = this.sanitizeCallback(cb);
 
-        cb = this.sanitizeCallback(cb);
-        const{ handler, errorHandler } = cb;
-
-        const ifSuccessfulResponse =
-            _.partialRight(this.ifSuccessfulResponse, {
-                errorHandler: errorHandler,
-                method: 'updateApplication'
-            });
-
-        this.getApplications((err, apps) => {
-
+        return this.getApplications((err, apps) => {
             if(err) {
-                errorHandler(err);
-                return;
+                return errorHandler(err);
             }
 
             const initializedConstraints = {
@@ -323,26 +357,22 @@ class KubernetesApi extends ApiImplementation {
                 }
             };
 
-            const existingApp = _.flow(
-                _.first,
-                _.partial(_.filter, _, (v, k) => k == appId))(apps);
-                //_.partial(_.omit, _, ['spec', 'template', 'spec', 'containers', 0, 'lifecycle']))(apps);
+            const existingApp = apps[appId];
 
             if(!existingApp) {
-                errorHandler(Error(`Couldn't find application with id ${appId} when in KubernetesApi::updateApplication!`));
-                return;
+                return errorHandler(`Couldn't find application with id ${appId} when in KubernetesApi::updateApplication!`);
             }
 
             // If we have an empty tags object, UI logic seems to dictate
             // that the tags get reinitialized.
-            const newApp = _.isNil(_.get(csAppDesc, ['tags', 'constraints'])) ?
-                _.merge(csAppDesc, initializedConstraints) : csAppDesc;
+            const newApp = _.isNil(_.get(csAppDesc, 'tags.constraints'))
+                ? _.merge(csAppDesc, initializedConstraints)
+                : csAppDesc;
 
             const k8sDesc =
                 Translator.csApplicationToK8SReplicationController(_.merge(existingApp, newApp));
 
-
-            request({
+            return request({
                 uri: `${this.k8sApiUrl}/api/v1/namespaces/default/replicationcontrollers/${appId}`,
                 method: 'PATCH',
                 body: k8sDesc,
@@ -350,23 +380,21 @@ class KubernetesApi extends ApiImplementation {
                 headers: {
                     'Content-Type': 'application/merge-patch+json'
                 }
-            }, ifSuccessfulResponse(handler));
+            }, (err, res, body) => {
+                if(err || res.statusCode !== 200) {
+                    return errorHandler('Failed to update application');
+                }
 
+                return handler(body);
+            });
         });
 
     }
 
     createApplication(csAppDesc, cb) {
+        const{ handler, errorHandler } = this.sanitizeCallback(cb);
 
-        cb = this.sanitizeCallback(cb);
-        const{ handler, errorHandler } = cb;
-
-        const ifSuccessfulResponse =
-            _.partialRight(this.ifSuccessfulResponse, {
-                errorHandler: errorHandler,
-                method: 'createApplication'
-            });
-
+        // hostPorts in kuber and host_port in containership are not equivalent... need to rework this
         const hostPort = _.cond([
             [(containerPort, hostPort, preferRandom) => preferRandom,
                 () => _.random(1, 65535)],
@@ -379,6 +407,17 @@ class KubernetesApi extends ApiImplementation {
 
         const containerPort = csAppDesc.container_port ? csAppDesc.container_port : hostPort;
 
+        // temporary shim for managed volumes in containership. builds a predefined
+        // host volume based on path and a uuid. note this will not be unique if
+        // more than one container is running on the same host currently
+        csAppDesc.volumes = _.map(csAppDesc.volumes || [], (vol) => {
+            if (_.isUndefined(vol.host)) {
+                vol.host = `/opt/containership/codexd/${csAppDesc.id}`;
+            }
+
+            return vol;
+        });
+
         const initialK8SAppDesc = Translator.csApplicationToK8SReplicationController(_.merge(csAppDesc, {
             host_port: hostPort,
             container_port: containerPort,
@@ -387,33 +426,42 @@ class KubernetesApi extends ApiImplementation {
 
         const k8sAppDesc = initialK8SAppDesc;
 
-        request({
+        return request({
             uri: `${this.k8sApiUrl}/api/v1/namespaces/default/replicationcontrollers`,
             method: 'POST',
             body: k8sAppDesc,
             json: true
-        }, ifSuccessfulResponse(() => {
+        }, (err, res, body) => {
+            if(err || res.statusCode !== 201) {
+                return errorHandler(`Could not create replication controller for ${csAppDesc.id}`);
+            }
 
             const ports = _.get(k8sAppDesc, ['spec', 'template', 'spec', 'containers', 0, 'ports'], []);
 
             if(_.size(ports) === 0) {
-                handler();
-            } else{
-                this.createService(k8sAppDesc, ports, [], ifSuccessfulResponse(handler));
+                return handler(body);
             }
 
-        }));
+            return this.createService(k8sAppDesc, ports, [], (err) => {
+                if(err) {
+                    return errorHandler(err);
+                }
 
+                return handler(body);
+            });
+        });
     }
 
     createApplications(csAppsDesc, cb) {
-        cb = this.sanitizeCallback(cb);
-        const{ handler, errorHandler } = cb;
+        const{ handler, errorHandler } = this.sanitizeCallback(cb);
 
         return async.each(csAppsDesc, (app, createCallback) => {
-            return this.createApplication(app, createCallback);
+            return this.createApplication(app, {
+                handler: (val) => createCallback(null, val),
+                errorHandler: (err) => createCallback(err)
+            });
         }, (err) => {
-            if (err) {
+            if(err) {
                 return errorHandler(err);
             }
 
@@ -422,185 +470,165 @@ class KubernetesApi extends ApiImplementation {
     }
 
     deleteApplication(name, cb) {
-        cb = this.sanitizeCallback(cb);
-        const{ handler, errorHandler } = cb;
+        const{ handler, errorHandler } = this.sanitizeCallback(cb);
 
-        const ifSuccessfulResponse =
-            _.partialRight(this.ifSuccessfulResponse, {
-                errorHandler: errorHandler,
-                method: 'deleteApplication'
-            });
+        return this.updateApplication(name, { tags: { constraints: {} }, count: 0 }, {
+            errorHandler,
+            handler: () => {
+                const self = this;
+                function safeDeleteRC(delete_cb) {
+                    return request({
+                        uri: `${self.k8sApiUrl}/api/v1/namespaces/default/replicationcontrollers/${name}`,
+                        method: 'GET'
+                    }, (err, res, body) => {
+                        if(err || res.statusCode !== 200) {
+                            return delete_cb(`Failed to retreive existing replica controller for application ${name}`);
+                        }
 
-        this.updateApplication(name, { tags: { constraints: {} }, count: 0 }, (err, res) => {
+                        const rc = JSON.parse(body);
+                        const podCount = _.get(rc, ['status', 'replicas'], Number.MAX_SAFE_INTEGER);
 
-            if(err) return errHandler(err);
+                        console.log('Surviving pod count: ' + podCount);
 
-            const self = this;
-            function safeDeleteRC() {
+                        if(podCount > 0) {
+                            return delete_cb(`There are still pods: ${podCount}...waiting 4 seconds for pods to delete`);
+                        }
 
-                request({
-                    uri: `${self.k8sApiUrl}/api/v1/namespaces/default/replicationcontrollers/${name}`,
-                    method: 'GET'
-                }, ifSuccessfulResponse((res) => {
+                        console.log('Making final delete.');
 
-                    const rc = JSON.parse(res.body);
-
-                    const podCount = _.get(rc, ['status', 'replicas'], Number.MAX_SAFE_INTEGER);
-
-                    console.log("Surviving pod count: " + podCount);
-
-                    if(podCount === 0) {
-
-                        console.log("Making final delete.");
-
-                        async.parallel([
+                        return async.parallel([
                             (cb) => {
                                 return request({
                                     uri: `${self.k8sApiUrl}/api/v1/namespaces/default/replicationcontrollers/${name}`,
                                     method: 'DELETE'
                                 }, (err, res) => {
-                                    if (err || res.statusCode !== 200) {
+                                    if(err || res.statusCode !== 200) {
                                         return cb(`Failed to delete replication controller: ${name}`);
                                     }
 
-                                    return cb(null, res);
+                                    return cb();
                                 });
                             },
                             (cb) => {
                                 self.deleteService(name, cb);
                             }
                         ], (err) => {
-                            if (err) {
-                                return errorHandler(err);
+                            if(err) {
+                                return delete_cb(err);
                             }
 
-                            return handler();
+                            return delete_cb();
                         });
+                    });
+                }
 
-                    } else {
-                        console.log("Trying again in 4 sec");
-                        setTimeout(safeDeleteRC, 4000);
+                return async.retry({ times: 5, interval: 4000 }, safeDeleteRC, (err) => {
+                    if(err) {
+                        return errorHandler(err);
                     }
-                }));
 
+                    return handler();
+                });
             }
-
-            // wait one second by default, so it always has
-            // a chance to scale down pods if they do exist
-            setTimeout(safeDeleteRC, 1000);
         });
-
     }
 
     //Look here!
     //Use os module to get info about master!
     getHosts(cb) {
-        cb = this.sanitizeCallback(cb);
-        const{ handler, errorHandler } = cb;
-        const ifSuccessfulResponse =
-            _.partialRight(this.ifSuccessfulResponse, {
-                errorHandler: errorHandler,
-                method: 'getHosts'
-            });
+        const{ handler, errorHandler } = this.sanitizeCallback(cb);
 
-        request(`${this.k8sApiUrl}/api/v1/nodes`, ifSuccessfulResponse((nodes) => {
-            nodes = util.safeParse(nodes.body);
+        return async.parallel({
+            nodes: (cb) => {
+                return request(`${this.k8sApiUrl}/api/v1/nodes`,
+                    (err, res, body) => {
+                        if(err || res.statusCode !== 200) {
+                            return cb('Failed to retrive k8s nodes inside getHosts call');
+                        }
 
-            request(`${this.k8sApiUrl}/api/v1/pods`, ifSuccessfulResponse((pods) => {
-                pods = util.safeParse(pods.body);
+                        return cb(null, util.safeParse(body));
+                    });
+            },
+            containers: (cb) => {
+                return this.getContainers((err, containers) => {
+                    return cb(err, containers);
+                });
+            }
+        }, (err, responses) => {
+            if(err) {
+                return errorHandler(err);
+            }
 
-                const k8sNodes = nodes.items;
-                const k8sPods = pods.items;
+            const containers = responses.containers;
+            const k8sNodes = responses.nodes.items;
 
-                const containersByNode = _.flow(
-                    _.partial(_.map, _, (pod) => {
-                        const nodeName = _.get(pod, ['spec', 'nodeName']);
+            const containersByNode = _.flow(
+                _.partial(_.map, _, (container) => {
+                    const csNodeName =
+                        _.flow(
+                            _.partial(_.filter, _, (n) => {
+                                return _.get(n, ['metadata', 'name']) === container.host;
+                            }),
+                            _.first,
+                            (node) => {
+                                return _.get(node, ['metadata', 'labels', 'cs-node-id'], 'NOT FOUND!');
+                            })(k8sNodes);
 
-                        const csNodeName =
-                            _.flow(
-                                _.partial(_.filter, _, (n) => {
-                                    return _.get(n, ['metadata', 'name']) === nodeName;
-                                }),
-                                _.first,
-                                (node) => {
-                                    return _.get(node, ['metadata', 'labels', 'cs-node-id'], 'NOT FOUND!');
-                                })(k8sNodes);
+                    return[csNodeName, container];
+                }),
+                _.partial(_.reduce, _, (result, nodeContainer) => {
+                    const[nodeName, container] = nodeContainer;
+                    const containersForNode = _.get(result, nodeName, []);
+                    return _.set(result, nodeName, _.concat(containersForNode, container));
+                }, {}))(containers);
 
-                        const k8sContainer = _.get(pod, 'spec');
-                        const status = _.get(pod, ['status', 'phase']);
-                        const containerID = _.replace(_.get(pod, ['status', 'containerStatuses', 0, 'containerID']), 'docker://', '');
-
-                        const csContainer = _.merge(
-                            Translator.csApplicationFromK8SPodSpec(k8sContainer),
-                            {
-                                status: status === 'Running' ? 'loaded' : 'unloaded',
-                                container_id: _.replace(containerID, 'docker://', ''),
-                                id: containerID
-                            });
-
-                        return[csNodeName, csContainer];
-                    }),
-                    _.partial(_.reduce, _, (result, nodeContainer) => {
-                        const[nodeName, container] = nodeContainer;
-                        const containersForNode = _.get(result, nodeName, []);
-                        return _.set(result, nodeName, _.concat(containersForNode, container));
-                    }, {}))(k8sPods);
-
-                const csFollowers = _.map(k8sNodes, _.flow(
-                    Translator.csHostFromK8SNode,
-                    (csNode) => _.merge(csNode, {
-                        'metadata': {
-                            'containership': {
-                                'version': '0.0.0'
-                            },
-                            'kubernetes': {
-                                'version':'1.3.8'
-                            }
-                        },
-                        'mode': 'follower',
-                        'praetor': {
-                            leader: false,
-                            leader_eligible: false,
-                            start_time: Date.now()
-                        },
-                        'containers': containersByNode[csNode.id] || []
-                    })));
-
-                const csLeader = {
-                    'id': process.argv[6] || os.hostname(),
-                    'host_name': os.hostname(),
-
+            const csFollowers = _.map(k8sNodes, _.flow(
+                Translator.csHostFromK8SNode,
+                (csNode) => _.merge(csNode, {
                     'metadata': {
-                        'containership': {
-                            'version': '0.0.0'
-                        },
                         'kubernetes': {
                             'version':'1.3.8'
                         }
                     },
-
-                    praetor: {
-                        leader: true,
-                        leader_eligible: true,
+                    'mode': 'follower',
+                    'praetor': {
+                        leader: false,
+                        leader_eligible: false,
                         start_time: Date.now()
                     },
+                    'containers': containersByNode[csNode.id] || []
+                })));
 
-                    mode: 'leader',
+            const csLeader = {
+                'id': process.argv[6] || os.hostname(),
+                'host_name': os.hostname(),
 
-                    address: {
-                        private: this.k8sApiIP,
-                        public: this.k8sApiIP
-                    },
+                'metadata': {
+                    'kubernetes': {
+                        'version':'1.3.8'
+                    }
+                },
 
-                    containers: []
-                };
+                praetor: {
+                    leader: true,
+                    leader_eligible: true,
+                    start_time: Date.now()
+                },
 
-                const keyed = _.keyBy(_.concat(csLeader, csFollowers), 'id');
+                mode: 'leader',
 
-                handler(keyed);
+                address: {
+                    private: this.k8sApiIP,
+                    public: this.k8sApiIP
+                },
 
-            }));
-        }));
+                containers: []
+            };
+
+            const keyed = _.keyBy(_.concat(csLeader, csFollowers), 'id');
+
+            return handler(keyed);
+        });
     }
 
     setDistributedKey(key, value, cb) {


### PR DESCRIPTION
* Cleaned up error handling and callback logic
* Removed use of successHandler and split error and regular handlers
* Removed a lot of the wrapper functions because you ended up with the same amount of
boilerplate but it caused you to have to jump to different files and base classes
to follow flow
* Fixed updateApplication to correctly pull existingApp from getApplications
* Cleaned up getApplication contianers to include unloaded
* million other bug fixes

@normanjoyner @jeremykross 