### PR TITLE
Removed host_port define in containers

### DIFF
--- a/lib/kubernetes-api.js
+++ b/lib/kubernetes-api.js
@@ -394,18 +394,7 @@ class KubernetesApi extends ApiImplementation {
     createApplication(csAppDesc, cb) {
         const{ handler, errorHandler } = this.sanitizeCallback(cb);
 
-        // hostPorts in kuber and host_port in containership are not equivalent... need to rework this
-        const hostPort = _.cond([
-            [(containerPort, hostPort, preferRandom) => preferRandom,
-                () => _.random(1, 65535)],
-            [(containerPort, hostPort, preferRandom) => !preferRandom && !hostPort && containerPort,
-                (containerPort) => containerPort],
-            [(containerPort, hostPort, preferRandom) => !preferRandom && hostPort,
-                (containerPort, hostPort) => hostPort],
-            [_.constant(true), () => _.random(1, 65535)]
-        ])(csAppDesc.container_port, csAppDesc.host_port, csAppDesc.random_host_port || false);
-
-        const containerPort = csAppDesc.container_port ? csAppDesc.container_port : hostPort;
+        const containerPort = csAppDesc.container_port ? csAppDesc.container_port : _.random(11024, 22047);
 
         // temporary shim for managed volumes in containership. builds a predefined
         // host volume based on path and a uuid. note this will not be unique if
@@ -419,9 +408,11 @@ class KubernetesApi extends ApiImplementation {
         });
 
         const initialK8SAppDesc = Translator.csApplicationToK8SReplicationController(_.merge(csAppDesc, {
-            host_port: hostPort,
             container_port: containerPort,
-            env_vars: { CS_ORCHESTRATOR: 'kubernetes' }
+            env_vars: {
+                CS_ORCHESTRATOR: 'kubernetes',
+                PORT: containerPort
+            }
         }));
 
         const k8sAppDesc = initialK8SAppDesc;


### PR DESCRIPTION
* Host_port was essentially cs dynamic port generation. Since in
kuber each pod has its own IP, they can have the same container ports
and we don't need to assign random hostport to container port mappings.

** This will have implications on how certain affects were achieved in plugins. E.g. the logs plugin. We need to now add the `containerIP` to a container definition and update plugins to hit that `ip:port` combo if we have code that expects to directly hit a specific container

@normanjoyner @jeremykross 