### PR TITLE
Updated container definitions with start_time and application

### DIFF
--- a/lib/kubernetes-api.js
+++ b/lib/kubernetes-api.js
@@ -269,9 +269,9 @@ class KubernetesApi extends ApiImplementation {
                     const nodeName = _.get(pod, 'spec.nodeName');
                     const k8sContainer = _.get(pod, 'spec');
                     const status = _.get(pod, 'status.phase');
-
+                    const start_time = Date.parse(_.get(pod, 'status.startTime'));
                     const containerID = _.get(pod, 'metadata.uid');
-
+                    const app_name = _.get(pod, 'metadata.labels.app');
                     const name = _.get(pod, 'status.containerStatuses[0].name');
                     const image = _.get(pod, 'status.containerStatuses[0].image');
 
@@ -283,7 +283,9 @@ class KubernetesApi extends ApiImplementation {
                             id: containerID,
                             name: name,
                             image: image,
-                            host: nodeName
+                            host: nodeName,
+                            start_time: start_time,
+                            application: app_name
                         }
                     );
 


### PR DESCRIPTION
* Updated containers to have start_time in epoch format
* Updated containers to have application_name keyed under application

@jeremykross @normanjoyner 

Fixes `hostContainerList` page and container `startTimestamps` in general on UI.