### PR TITLE
Only use host_port if the network mode is host

### DIFF
--- a/lib/kubernetes-api.js
+++ b/lib/kubernetes-api.js
@@ -442,7 +442,9 @@ class KubernetesApi extends ApiImplementation {
     createApplication(csAppDesc, cb) {
         const{ handler, errorHandler } = this.sanitizeCallback(cb);
 
-        const containerPort = csAppDesc.container_port ? csAppDesc.container_port : _.random(11024, 22047);
+        // only use provided host port if it is in `host` network mode
+        const hostPort = (csAppDesc.network_mode && csAppDesc.network_mode === 'host') ? csAppDesc.host_port : null;
+        const containerPort = hostPort ? hostPort : (csAppDesc.container_port ? csAppDesc.container_port : _.random(11024, 22047));
 
         // temporary shim for managed volumes in containership. builds a predefined
         // host volume based on path and a uuid. note this will not be unique if


### PR DESCRIPTION
* Container_port gets set to host_port if it exists in case of host network mode
* Otherwise container port gets randomized