### PR TITLE
Pull current node version from `/version` route

### DIFF
--- a/lib/kubernetes-api.js
+++ b/lib/kubernetes-api.js
@@ -777,6 +777,22 @@ class KubernetesApi extends ApiImplementation {
                 return this.getContainers((err, containers) => {
                     return cb(err, containers);
                 });
+            },
+            version: (cb) => {
+                return request({
+                    method: 'GET',
+                    uri: `${this.k8sApiUrl}/version`
+                }, (err, res, body) => {
+                    if (err || res.statusCode !== 200) {
+                        return cb(err || body);
+                    }
+
+                    try {
+                        return cb(null, JSON.parse(body).gitVersion);
+                    } catch (parseError) {
+                        return cb(parseError);
+                    }
+                });
             }
         }, (err, responses) => {
             if(err) {
@@ -786,7 +802,6 @@ class KubernetesApi extends ApiImplementation {
             const containers = responses.containers;
             const k8sNodes = responses.nodes.items;
             const k8sServices = responses.services.items;
-
 
             const k8sCoreService = _.find(k8sServices, (s) => {
                 return _.get(s, 'metadata.name') === 'kubernetes';
@@ -815,11 +830,6 @@ class KubernetesApi extends ApiImplementation {
             const csFollowers = _.map(k8sNodes, _.flow(
                 Translator.csHostFromK8SNode,
                 (csNode) => _.merge(csNode, {
-                    'metadata': {
-                        'kubernetes': {
-                            'version':'1.3.8'
-                        }
-                    },
                     'mode': 'follower',
                     'praetor': {
                         leader: false,
@@ -837,7 +847,7 @@ class KubernetesApi extends ApiImplementation {
 
                 'metadata': {
                     'kubernetes': {
-                        'version':'1.3.8'
+                        'version': responses.version
                     }
                 },
 


### PR DESCRIPTION
* Followers are pulled from `nodeInfo`

Depends on : https://github.com/containership/containership.k8s.translator/pull/18

@normanjoyner @jeremykross 