### PR TITLE
host_port restrictions on app update depending on network_mode

### DIFF
--- a/lib/kubernetes-api.js
+++ b/lib/kubernetes-api.js
@@ -497,6 +497,21 @@ class KubernetesApi extends ApiImplementation {
                 return cb(err);
             }
 
+            // if updating to host mode, need to ensure new app host_port === container_port
+            if (app_desc_update.network_mode === 'host') {
+                app_desc_update.host_port = app_desc_update.container_port || existing_app.container_port;
+            }
+
+            // if existing app is in host mode and we are not updating to bridge mode, and providing a new container_port, we must update host port
+            if (existing_app.network_mode === 'host' && !app_desc_update.network_mode !== 'bridge' && app_desc_update.container_port !== undefined) {
+                app_desc_update.host_port = app_desc_update.container_port;
+            }
+
+            // if we are switching to bridge mode, set the host_port to null so it is managed by kubernetes
+            if (app_desc_update.network_mode === 'bridge') {
+                app_desc_update.host_port = null;
+            }
+
             let properties = _.keys(flatten(app_desc_update));
 
             const replication_controller_needs_updated = !_.isEmpty(properties);


### PR DESCRIPTION
Need to do some additional constraint logic when updating ports on applications depending whether or not the existing app is in `host` mode or if the update is converting the app to `host` mode

@normanjoyner @jeremykross 