### PR TITLE
Remove async.waterfall

### DIFF
--- a/lib/kubernetes-api.js
+++ b/lib/kubernetes-api.js
@@ -830,7 +830,7 @@ class KubernetesApi extends ApiImplementation {
 
             const { hosts, etcd_members } = result;
 
-            async.waterfall([
+            async.series([
 
                 (cb) => {
                     const host = hosts[host_id];


### PR DESCRIPTION
* no need for async.waterfall when we are not passing data from one task to the next

@normanjoyner @jeremykross 