### PR TITLE
Inject CS_API_IP as env variable

### DIFF
--- a/lib/kubernetes-api.js
+++ b/lib/kubernetes-api.js
@@ -50,6 +50,16 @@ class KubernetesApi extends ApiImplementation {
                     return cb(null, app_desc);
                 },
 
+                // inject some standard CS_ vars
+                (app_desc, cb) => {
+                    app_desc.env_vars = app_desc.env_vars || {};
+
+                    app_desc.env_vars.CS_ORCHESTRATOR = 'kubernetes';
+                    app_desc.env_vars.CS_API_IP = this.k8s_api_ip;
+
+                    return cb(null, app_desc);
+                },
+
                 // build service discovery environment variables
                 (app_desc, cb) => {
                     app_desc.env_vars = app_desc.env_vars || {};


### PR DESCRIPTION
@normanjoyner 

Going to be used in marketplace apps, specifically `docker-cs-prometheus-server` to get a reference to the private api IP in order to build the `k8s api` when in bridge mode.