### PR TITLE
Fix for server error when supplying numberic tags.

### DIFF
--- a/lib/kubernetes-api.js
+++ b/lib/kubernetes-api.js
@@ -653,7 +653,7 @@ class KubernetesApi extends ApiImplementation {
                         const tags = _.flow(
                             _.partial(_.get, _, 'tags'),
                             _.partial(_.omit, _, 'metadata', 'constraints'),
-                            (t) => !_.isEmpty(t) ? { tags: t } : {},
+                            (t) => !_.isEmpty(t) ? { tags: `${t}` } : {},
                             flatten)(existing_app);
 
                         // Apply them to the kubernetes nodeSelector.


### PR DESCRIPTION
@nicktate @ashleyschuett 

-- the crash was actually caused, I think, by the nodeSelector which also has to be a string and doesn't pass through the translator. 